### PR TITLE
Test for "artistId" before referencing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-hello Python iTunes
+Python iTunes
 =============
 
 A simple python wrapper to access iTunes Store API http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html


### PR DESCRIPTION
I found when I searched for "The Godfather", the results returned as tracks.  But they did not have an artistId on them, and thus it threw an error when the Track and Album classes attempted to reference the artistId.  A check before referencing fixed the issue.
