### PR TITLE
Fix #12: missing `collectionPrice`

### DIFF
--- a/itunes/__init__.py
+++ b/itunes/__init__.py
@@ -395,7 +395,7 @@ class Album(Item):
         self.url = json.get('collectionViewUrl', None)
         self.amg_id = json.get('amgAlbumId', None)
 
-        self.price = round(json['collectionPrice'] or 0, 4)
+        self.price = round(json.get('collectionPrice', 0) or 0, 4)
         self.price_currency = json['currency']
         self.track_count = json['trackCount']
         self.copyright = json.get('copyright', None)


### PR DESCRIPTION
Use `dict.get()` to avoid raising an exception when the data is missing, as suggested by @ocelma.
